### PR TITLE
Fix search query parameter handling in HomeRepository

### DIFF
--- a/app/src/androidTest/java/com/example/thamanyahaudiotask/FakeHomeRepository.kt
+++ b/app/src/androidTest/java/com/example/thamanyahaudiotask/FakeHomeRepository.kt
@@ -3,6 +3,7 @@ package com.example.thamanyahaudiotask
 import com.example.thmanyahaudiotask.repositories.homeRepository.HomeRepository
 import com.example.thmanyahaudiotask.repositories.homeRepository.models.HomeSectionsDTO
 import com.example.thmanyahaudiotask.repositories.homeRepository.models.Pagination
+import com.example.thmanyahaudiotask.repositories.homeRepository.models.SearchResponseDTO
 import com.example.thmanyahaudiotask.utils.Resource
 
 class FakeHomeRepository : HomeRepository {
@@ -12,9 +13,9 @@ class FakeHomeRepository : HomeRepository {
         )
     }
 
-    override suspend fun searchHomeSections(query: String): Resource<HomeSectionsDTO> {
+    override suspend fun searchHomeSections(query: String): Resource<SearchResponseDTO> {
         return Resource.Success(
-            HomeSectionsDTO(sections = listOf(), pagination = Pagination())
+            SearchResponseDTO(sections = listOf())
         )
     }
 

--- a/app/src/main/java/com/example/thmanyahaudiotask/repositories/homeRepository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/example/thmanyahaudiotask/repositories/homeRepository/HomeRepositoryImpl.kt
@@ -31,7 +31,7 @@ class HomeRepositoryImpl(
 
     override suspend fun searchHomeSections(query: String): Resource<SearchResponseDTO> {
         return try {
-            val response = homeApi.searchHomeSections()
+            val response = homeApi.searchHomeSections(query)
             Resource.Success(response)
         } catch (exception: Exception) {
             Log.d("HomeRepositoryImpl", "searchHomeSections: ${exception.message}")

--- a/app/src/main/java/com/example/thmanyahaudiotask/repositories/homeRepository/remoteDataSource/HomeApi.kt
+++ b/app/src/main/java/com/example/thmanyahaudiotask/repositories/homeRepository/remoteDataSource/HomeApi.kt
@@ -2,7 +2,6 @@ package com.example.thmanyahaudiotask.repositories.homeRepository.remoteDataSour
 
 import com.example.thmanyahaudiotask.repositories.homeRepository.models.HomeSectionsDTO
 import com.example.thmanyahaudiotask.repositories.homeRepository.models.SearchResponseDTO
-import com.example.thmanyahaudiotask.repositories.homeRepository.models.SearchSectionDTO
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -13,5 +12,7 @@ interface HomeApi {
     ): HomeSectionsDTO
 
     @GET("https://mock.apidog.com/m1/735111-711675-default/search")
-    suspend fun searchHomeSections(): SearchResponseDTO
+    suspend fun searchHomeSections(
+        @Query("query") query: String
+    ): SearchResponseDTO
 }


### PR DESCRIPTION
## Summary
- include query parameter in HomeApi.searchHomeSections and forward from HomeRepositoryImpl
- align FakeHomeRepository with new search contract
- remove unused import

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971c1804f483269c2877c9babbd422