### PR TITLE
Refactor HomeViewModelTest for MVI

### DIFF
--- a/app/src/test/java/com/example/thamanyahaudiotask/ui/home/presenter/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/thamanyahaudiotask/ui/home/presenter/HomeViewModelTest.kt
@@ -6,6 +6,7 @@ import com.example.thamanyahaudiotask.domain.homeFakeUiModel
 import com.example.thmanyahaudiotask.domain.GetHomeSectionsUseCase
 import com.example.thmanyahaudiotask.repositories.homeRepository.HomeRepository
 import com.example.thmanyahaudiotask.utils.Resource
+import com.example.thamanyahaudiotask.utils.MainDispatcherRule
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -13,6 +14,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.Rule
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -28,6 +30,9 @@ class HomeViewModelTest {
 
     private var closeable: AutoCloseable? = null
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
     @Before
     fun setUp() {
         closeable = MockitoAnnotations.openMocks(this)
@@ -40,7 +45,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `load initial data success updates state`() = runTest {
+    fun `load initial data success updates state`() = runTest(mainDispatcherRule.testDispatcher) {
         `when`(homeRepository.getHomeSections()).thenReturn(
             Resource.Success(
                 data = homeFakeSectionsDTO
@@ -61,7 +66,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `refresh emits refreshing then data`() = runTest {
+    fun `refresh emits refreshing then data`() = runTest(mainDispatcherRule.testDispatcher) {
         `when`(homeRepository.getHomeSections()).thenReturn(
             Resource.Success(homeFakeSectionsDTO),
             Resource.Success(homeFakeSectionsDTO)
@@ -89,7 +94,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `load next page appends data`() = runTest {
+    fun `load next page appends data`() = runTest(mainDispatcherRule.testDispatcher) {
         `when`(homeRepository.getHomeSections()).thenReturn(
             Resource.Success(homeFakeSectionsDTO),
             Resource.Success(homeFakeSectionsDTO)

--- a/app/src/test/java/com/example/thamanyahaudiotask/ui/home/presenter/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/thamanyahaudiotask/ui/home/presenter/HomeViewModelTest.kt
@@ -4,14 +4,13 @@ import app.cash.turbine.test
 import com.example.thamanyahaudiotask.domain.homeFakeSectionsDTO
 import com.example.thamanyahaudiotask.domain.homeFakeUiModel
 import com.example.thmanyahaudiotask.domain.GetHomeSectionsUseCase
-import com.example.thmanyahaudiotask.domain.SearchUseCase
 import com.example.thmanyahaudiotask.repositories.homeRepository.HomeRepository
-import com.example.thmanyahaudiotask.ui.home.presenter.HomeUIStates
-import com.example.thmanyahaudiotask.ui.home.presenter.HomeViewModel
 import com.example.thmanyahaudiotask.utils.Resource
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -24,8 +23,6 @@ class HomeViewModelTest {
 
     private lateinit var homeSectionsUseCase: GetHomeSectionsUseCase
 
-    private lateinit var searchUseCase: SearchUseCase
-
     @Mock
     private lateinit var homeRepository: HomeRepository
 
@@ -35,53 +32,89 @@ class HomeViewModelTest {
     fun setUp() {
         closeable = MockitoAnnotations.openMocks(this)
         homeSectionsUseCase = GetHomeSectionsUseCase(homeRepository)
-        searchUseCase = SearchUseCase(homeRepository)
-        viewModel = HomeViewModel(homeSectionsUseCase, searchUseCase)
-    }
-
-    @Test
-    fun fetchData() = runTest {
-        // Simulate a successful fetch
-        `when`(homeRepository.getHomeSections()).thenReturn(
-            Resource.Success(
-                data = homeFakeSectionsDTO
-            )
-        )
-        viewModel.fetchData()
-
-        viewModel.uiState.test {
-            // Verify that the UI state is updated to Success with the expected data
-            assertEquals(HomeUIStates.Loading, awaitItem())
-            assertEquals(HomeUIStates.Success(listOf(homeFakeUiModel)), awaitItem())
-        }
-    }
-
-    @Test
-    fun onSearchClick() = runTest {
-        // Simulate a search click
-
-        viewModel.onSearchClick()
-
-        // Verify that the search query is set correctly
-        viewModel.uiState.test {
-            assertEquals(HomeUIStates.SearchMode(""), awaitItem())
-        }
-    }
-
-    @Test
-    fun onQueryChanged() = runTest {
-        // Simulate a query change
-        val query = "test query"
-        viewModel.onQueryChanged(query)
-
-        // Verify that the UI state is updated to SearchMode with the new query
-        viewModel.uiState.test {
-            assertEquals(HomeUIStates.SearchMode(query), awaitItem())
-        }
     }
 
     @After
     fun tearDown() {
         closeable?.close()
     }
+
+    @Test
+    fun `load initial data success updates state`() = runTest {
+        `when`(homeRepository.getHomeSections()).thenReturn(
+            Resource.Success(
+                data = homeFakeSectionsDTO
+            )
+        )
+
+        viewModel = HomeViewModel(homeSectionsUseCase)
+
+        viewModel.state.test {
+            assertEquals(HomeState(), awaitItem())
+            assertEquals(HomeState(isLoading = true), awaitItem())
+            assertEquals(
+                HomeState(sections = listOf(homeFakeUiModel)),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `refresh emits refreshing then data`() = runTest {
+        `when`(homeRepository.getHomeSections()).thenReturn(
+            Resource.Success(homeFakeSectionsDTO),
+            Resource.Success(homeFakeSectionsDTO)
+        )
+
+        viewModel = HomeViewModel(homeSectionsUseCase)
+
+        viewModel.state.test {
+            awaitItem() // initial
+            awaitItem() // loading
+            awaitItem() // initial data
+
+            viewModel.process(HomeEvent.Refresh)
+
+            val refreshing = awaitItem()
+            assertTrue(refreshing.isRefreshing)
+            assertEquals(listOf(homeFakeUiModel), refreshing.sections)
+
+            val refreshed = awaitItem()
+            assertFalse(refreshed.isRefreshing)
+            assertEquals(listOf(homeFakeUiModel), refreshed.sections)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `load next page appends data`() = runTest {
+        `when`(homeRepository.getHomeSections()).thenReturn(
+            Resource.Success(homeFakeSectionsDTO),
+            Resource.Success(homeFakeSectionsDTO)
+        )
+
+        viewModel = HomeViewModel(homeSectionsUseCase)
+
+        viewModel.state.test {
+            awaitItem() // initial
+            awaitItem() // loading
+            val firstData = awaitItem()
+            assertEquals(listOf(homeFakeUiModel), firstData.sections)
+
+            viewModel.process(HomeEvent.LoadNextPage)
+
+            val loadingMore = awaitItem()
+            assertTrue(loadingMore.isLoadingMore)
+            assertEquals(listOf(homeFakeUiModel), loadingMore.sections)
+
+            val appended = awaitItem()
+            assertFalse(appended.isLoadingMore)
+            assertEquals(listOf(homeFakeUiModel, homeFakeUiModel), appended.sections)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }
+

--- a/app/src/test/java/com/example/thamanyahaudiotask/utils/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/thamanyahaudiotask/utils/MainDispatcherRule.kt
@@ -1,0 +1,24 @@
+package com.example.thamanyahaudiotask.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
## Summary
- update HomeViewModelTest to new MVI event/state pattern
- add tests for initial load, refresh, and pagination

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b95d046b483269aa5d7c1ce99fab4